### PR TITLE
catch up with 0.8.2 API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,24 @@
     <dependencies>
         <dependency>
             <groupId>com.graphhopper</groupId>
-            <artifactId>graphhopper</artifactId>
-            <version>0.6-SNAPSHOT</version>
+            <artifactId>graphhopper-core</artifactId>
+            <version>0.8.2</version>
         </dependency>
-        
+        <dependency>
+            <groupId>com.graphhopper</groupId>
+            <artifactId>graphhopper-reader-osm</artifactId>
+            <version>0.8.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.graphhopper</groupId>
+            <artifactId>graphhopper-reader-osm</artifactId>
+            <version>0.8.2</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>   
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,6 @@
             <version>0.8.2</version>
         </dependency>
         <dependency>
-            <groupId>com.graphhopper</groupId>
-            <artifactId>graphhopper-reader-osm</artifactId>
-            <version>0.8.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/src/main/java/com/graphhopper/osmidexample/MyGraphHopper.java
+++ b/src/main/java/com/graphhopper/osmidexample/MyGraphHopper.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper and Peter Karich under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for 
+ *  license agreements. See the NOTICE file distributed with this work for
  *  additional information regarding copyright ownership.
- * 
- *  GraphHopper licenses this file to you under the Apache License, 
- *  Version 2.0 (the "License"); you may not use this file except in 
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
  *  compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,7 @@ import com.graphhopper.GHRequest;
 import com.graphhopper.GHResponse;
 import com.graphhopper.GraphHopper;
 import com.graphhopper.reader.DataReader;
-import com.graphhopper.reader.OSMReader;
+import com.graphhopper.reader.osm.OSMReader;
 import com.graphhopper.routing.Path;
 import com.graphhopper.storage.DataAccess;
 import com.graphhopper.storage.Directory;
@@ -82,7 +82,7 @@ public class MyGraphHopper extends GraphHopper {
             }
         };
 
-        return initOSMReader(reader);
+        return initDataReader(reader);
     }
 
     public long getOSMWay(int internalEdgeId) {
@@ -91,7 +91,7 @@ public class MyGraphHopper extends GraphHopper {
     }
 
     @Override
-    public List<Path> getPaths(GHRequest request, GHResponse rsp) {
-        return super.getPaths(request, rsp);
+    public List<Path> calcPaths(GHRequest request, GHResponse rsp) {
+        return super.calcPaths(request, rsp);
     }
 }

--- a/src/main/java/com/graphhopper/osmidexample/MyImport.java
+++ b/src/main/java/com/graphhopper/osmidexample/MyImport.java
@@ -1,14 +1,14 @@
 /*
  *  Licensed to GraphHopper and Peter Karich under one or more contributor
- *  license agreements. See the NOTICE file distributed with this work for 
+ *  license agreements. See the NOTICE file distributed with this work for
  *  additional information regarding copyright ownership.
- * 
- *  GraphHopper licenses this file to you under the Apache License, 
- *  Version 2.0 (the "License"); you may not use this file except in 
+ *
+ *  GraphHopper licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
  *  compliance with the License. You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,9 +44,9 @@ public class MyImport {
         Logger logger = LoggerFactory.getLogger(MyImport.class);
         logger.info("edge 30 -> " + graphHopper.getOSMWay(30) + ", " + graphHopper.getGraphHopperStorage().getEdgeIteratorState(30, Integer.MIN_VALUE).fetchWayGeometry(2));
 
-        GHResponse rsp = new GHResponse();        
-        List<Path> paths = graphHopper.getPaths(new GHRequest(52.498668, 13.431473, 52.48947, 13.404007).
-                setWeighting("fastest").setVehicle("car"), rsp);        
+        GHResponse rsp = new GHResponse();
+        List<Path> paths = graphHopper.calcPaths(new GHRequest(52.498668, 13.431473, 52.48947, 13.404007).
+                setWeighting("fastest").setVehicle("car"), rsp);
         Path path0 = paths.get(0);
         for (EdgeIteratorState edge : path0.calcEdges()) {
             int edgeId = edge.getEdge();


### PR DESCRIPTION
The current stable GraphHopper version is 0.8.2 and some APIs have changed since V0.6. The code in the master does not work. I follow the change log of GraphHopper and make this repo catch up with the 0.8.2 API.